### PR TITLE
Current SSL ciphers break Chrome 53

### DIFF
--- a/nginx/files/_ssl_normal.conf
+++ b/nginx/files/_ssl_normal.conf
@@ -1,6 +1,6 @@
 
 ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
-ssl_ciphers "EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH";
+ssl_ciphers "ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:ECDH+3DES:DH+3DES:RSA+AES:RSA+3DES:!ADH:!AECDH:!MD5:!DSS";
 ssl_prefer_server_ciphers on;
 ssl_ecdh_curve secp521r1;
 

--- a/nginx/files/_ssl_secure.conf
+++ b/nginx/files/_ssl_secure.conf
@@ -1,6 +1,6 @@
 
 ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
-ssl_ciphers "EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH";
+ssl_ciphers "ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:ECDH+3DES:DH+3DES:RSA+AES:RSA+3DES:!ADH:!AECDH:!MD5:!DSS";
 ssl_prefer_server_ciphers on;
 ssl_ecdh_curve secp521r1;
 ssl_dhparam /etc/ssl/dhparams.pem;

--- a/nginx/files/proxy.conf
+++ b/nginx/files/proxy.conf
@@ -55,6 +55,11 @@ server {
       {%- else %}
       proxy_redirect off;
       {%- endif %}
+      
+      {%- if site.proxy.request_buffer is defined %}
+      proxy_request_buffering off;
+      {%- endif %}
+
 
       {%- if site.proxy.buffer is defined %}
       {%- set buffer_size = site.proxy.buffer.get('size', 16) * 2 %}


### PR DESCRIPTION
The SSL ciphers used are not working with Chrome, we get the following error:

Unsupported protocol
The client and server don't support a common SSL protocol version or cipher suite.

The new ciphers have been confirmed to work successfully.

I have also added in the option for proxy_request_buffering as it is something we use in our deployment.
