### PR TITLE
Fix redirect to http://_/

### DIFF
--- a/nginx/files/redirect.conf
+++ b/nginx/files/redirect.conf
@@ -6,6 +6,6 @@ server {
   {%- if site.redirect is defined %}
   rewrite ^(.*)   {{ site.redirect.get('protocol', 'http') }}://{{ site.redirect.get('host', '$server_name') }}{{ site.redirect.get('path', '$1') }} permanent;
   {%- else %}
-  rewrite ^(.*)   https://$server_name$1 permanent;
+  rewrite ^(.*)   https://$host$1 permanent;
   {%- endif %}
 }


### PR DESCRIPTION
If site is empty, or redirect is not specified, it should use $http_host
