### PR TITLE
Fixed error upstream sent too big header while reading response heade…

### DIFF
--- a/nginx/files/proxy.conf
+++ b/nginx/files/proxy.conf
@@ -56,6 +56,10 @@ server {
       proxy_redirect off;
       {%- endif %}
 
+      proxy_buffer_size   128k;
+      proxy_buffers   4 256k;
+      proxy_busy_buffers_size   256k;
+
       {%- if site.proxy.buffer is defined %}
       {%- set buffer_size = site.proxy.buffer.get('size', 16) * 2 %}
       proxy_buffering on;


### PR DESCRIPTION
…r from upstream

Should fix this error http://stackoverflow.com/questions/23844761/upstream-sent-too-big-header-while-reading-response-header-from-upstream.
