### PR TITLE
Fix match in nginx_check alarm cluster

### DIFF
--- a/nginx/meta/heka.yml
+++ b/nginx/meta/heka.yml
@@ -36,7 +36,7 @@ aggregator:
       policy: highest_severity
       alerting: enabled_with_notification
       match:
-        service: nginx
+        service: nginx-check
       members:
       - nginx_check
       dimension:


### PR DESCRIPTION
This fixes a small but efficient bug introduced by https://github.com/tcpcloud/salt-formula-nginx/pull/22.