### PR TITLE
add proxy_busy_buffers_size option

### DIFF
--- a/nginx/files/proxy.conf
+++ b/nginx/files/proxy.conf
@@ -61,6 +61,7 @@ server {
       proxy_buffering on;
       proxy_buffers {{ site.proxy.buffer.get('number', 8) }} {{ site.proxy.buffer.get('size', 16) }}k;
       proxy_buffer_size {{ buffer_size }}k;
+      proxy_busy_buffers_size {{ site.proxy.buffer.get('busy', buffer_size) }}k;
       {%- else %}
       proxy_buffering off;
       {%- endif %}


### PR DESCRIPTION
I found it required together with other proxy options otherwise nginx not startad as proxy buffers sizes not within the size of another attribute. More at: https://mirantis.jira.com/browse/RIL-300