### PR TITLE
Fix creation of all chain file

### DIFF
--- a/nginx/server/sites.sls
+++ b/nginx/server/sites.sls
@@ -75,8 +75,9 @@
 {% endif %}
 
 nginx_init_{{ site.host.name }}_tls:
-  cmd.wait:
+  cmd.run:
   - name: "cat {{ cert_file }} {{ ca_file }} > {{ chain_file }}"
+  - creates: {{ chain_file }}
   - watch_in:
     - service: nginx_service
 


### PR DESCRIPTION
Problem is that it doesn't get created if key file and cert already exists and 
are not deployed by nginx state. So ensure all file always exists. However I
am not sure how this will behave if key and cert will get changed. Maybe it
would be better to use file.managed and template instead.