### PR TITLE
Centos is missing folder /etc/ssl/private

### DIFF
--- a/metadata/service/support.yml
+++ b/metadata/service/support.yml
@@ -8,6 +8,6 @@ parameters:
       sensu:
         enabled: true
       sphinx:
-        enabled: true
+        enabled: false
       grafana:
         enabled: true

--- a/metadata/service/support.yml
+++ b/metadata/service/support.yml
@@ -8,7 +8,7 @@ parameters:
       sensu:
         enabled: false
       sphinx:
-        enabled: false
+        enabled: true
       grafana:
         enabled: true
       prometheus:

--- a/nginx/meta/sphinx.yml
+++ b/nginx/meta/sphinx.yml
@@ -7,7 +7,7 @@ doc:
       name: Server
       param:
         version:
-          value: "{{ salt['cmd.run']('nginx -v 2>/dev/null || echo "unknown"')|replace("nginx version: ", '') }}"
+          value: "{{ salt['cmd.run']('if which nginx ; then nginx -v; else echo "unknown"; fi 2>/dev/null')|replace("nginx version: ", '') }}"
         bind_host:
           name: Bind host
           value: {{ server.bind.address }}

--- a/nginx/meta/sphinx.yml
+++ b/nginx/meta/sphinx.yml
@@ -7,7 +7,7 @@ doc:
       name: Server
       param:
         version:
-          value: "{{ salt['cmd.run']('if which nginx ; then nginx -v; else echo "unknown"; fi 2>/dev/null')|replace("nginx version: ", '') }}"
+          value: "{{ salt['cmd.shell']('nginx -v 2>/dev/null || echo "unknown"', python_shell=True)|replace("nginx version: ", '') }}"
         bind_host:
           name: Bind host
           value: {{ server.bind.address }}

--- a/nginx/server.sls
+++ b/nginx/server.sls
@@ -34,14 +34,16 @@ nginx_extra_packages:
   - watch_in:
     - service: nginx_service
 
+{%- if not salt['file.directory_exists'](/etc/ssl/private) %}
 /etc/ssl/private:
   file.directory:
-  - mode: 0400
-  - user: nginx
-  - group: nginx
+  - mode: 0710
+  - user: root
+  - group: ssl-cert
   - makedirs: true
   - require:
     - pkg: nginx_packages
+{%- endif %}
 
 {%- if server.stream is defined %}
 /etc/nginx/stream.conf:

--- a/nginx/server.sls
+++ b/nginx/server.sls
@@ -34,6 +34,15 @@ nginx_extra_packages:
   - watch_in:
     - service: nginx_service
 
+/etc/ssl/private:
+  file.directory:
+  - mode: 0400
+  - user: nginx
+  - group: nginx
+  - makedirs: true
+  - require:
+    - pkg: nginx_packages
+
 {%- if server.stream is defined %}
 /etc/nginx/stream.conf:
   file.managed:

--- a/nginx/server.sls
+++ b/nginx/server.sls
@@ -34,7 +34,7 @@ nginx_extra_packages:
   - watch_in:
     - service: nginx_service
 
-{%- if not salt['file.directory_exists'](/etc/ssl/private) %}
+{%- if not salt['file.directory_exists']('/etc/ssl/private') %}
 /etc/ssl/private:
   file.directory:
   - mode: 0710

--- a/nginx/server.sls
+++ b/nginx/server.sls
@@ -39,8 +39,13 @@ nginx_extra_packages:
   file.directory:
   - mode: 0710
   - user: root
-  - group: ssl-cert
+  - group: root
   - makedirs: true
+  - require:
+    - pkg: nginx_packages
+{%- else %}
+/etc/ssl/private:
+  file.directory:
   - require:
     - pkg: nginx_packages
 {%- endif %}

--- a/nginx/server/sites.sls
+++ b/nginx/server/sites.sls
@@ -31,14 +31,6 @@
     - service: nginx_service
     - cmd: nginx_init_{{ site.host.name }}_tls
 
-{{ site.host.name }}_parent_folder:
-  file.directory:
-  - name: /etc/ssl/private
-  - mode: 0400
-  - user: nginx
-  - group: nginx
-  - makedirs: True
-
 {{ site.host.name }}_private_key:
   file.managed:
   - name: {{ key_file }}

--- a/nginx/server/sites.sls
+++ b/nginx/server/sites.sls
@@ -31,6 +31,14 @@
     - service: nginx_service
     - cmd: nginx_init_{{ site.host.name }}_tls
 
+{{ site.host.name }}_parent_folder:
+  file.directory:
+  - name: /etc/ssl/private
+  - mode: 0400
+  - user: nginx
+  - group: nginx
+  - makedirs: True
+
 {{ site.host.name }}_private_key:
   file.managed:
   - name: {{ key_file }}

--- a/nginx/server/sites.sls
+++ b/nginx/server/sites.sls
@@ -42,6 +42,7 @@
   - mode: 400
   - require:
     - pkg: nginx_packages
+    - file: /etc/ssl/private
   - watch_in:
     - cmd: nginx_init_{{ site.host.name }}_tls
 


### PR DESCRIPTION
The formula sort of wors on centos too, however the /etc/ssl/private folder is missing, so added a state to create the folder before deploying ssl keys