### PR TITLE
Add option to enable service

### DIFF
--- a/nginx/server.sls
+++ b/nginx/server.sls
@@ -106,8 +106,8 @@ nginx_service:
   - name: {{ server.service }}
   - require:
     - pkg: nginx_packages
-{%- if server.service_enable is defined and server.service_enable %}
-  - enable: true
+{%- if server.service_enable is defined %}
+  - enable: {{ server.service_enable }}
 {%- endif %}
 
 {%- set generate_dhparams = { 'enabled': False } %}

--- a/nginx/server.sls
+++ b/nginx/server.sls
@@ -77,6 +77,9 @@ nginx_service:
   - name: {{ server.service }}
   - require:
     - pkg: nginx_packages
+{%- if server.service_enable is defined and server.service_enable %}
+  - enable: true
+{%- endif %}
 
 {%- set generate_dhparams = { 'enabled': False } %}
 {%- for site_name, site in server.get('site', {}).iteritems() %}


### PR DESCRIPTION
There seems to be no current way of enabling the nginx service optionally from a pillar ( See #42 ).

This PR adds a simple option to allow the service to be enabled (or not) through pillar data.