### PR TITLE
Fix obtaining version information for sphinx grains.

### DIFF
--- a/nginx/meta/sphinx.yml
+++ b/nginx/meta/sphinx.yml
@@ -7,7 +7,7 @@ doc:
       name: Server
       param:
         version:
-          value: "{{ salt['cmd.shell']('nginx -v 2>/dev/null || echo "unknown"', python_shell=True)|replace("nginx version: ", '') }}"
+          value: "{{ salt['cmd.shell']('which nginx >/dev/null && nginx -v || echo "Not installed"', python_shell=True)|replace("nginx version: ", '') }}"
         bind_host:
           name: Bind host
           value: {{ server.bind.address }}


### PR DESCRIPTION
This fixes obtaining version info from nginx, that is put into grains (sphinx).
It is printed to stderr, so nginx -v 2>/dev/null discards it.
It also handles case when nginx is not (yet) installed.